### PR TITLE
Add placeholder feature for activity card when loading the image

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "antd": "3.6.6",
     "object-assign": "4.1.1",
-    "antd": "3.6.6"
+    "react-loadable": "^5.5.0"
   },
   "scripts": {
     "start": "node scripts/start.js",

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -4,6 +4,10 @@ import Col from 'antd/es/col';
 import Card from 'antd/es/card';
 import Timeline from 'antd/es/timeline';
 import { activityTypeEnum, IAchievement } from '@/config/achievements.config';
+import LazyImg from './LazyImg';
+
+const IMAGE_PLACEHOLDER = '/static/imgs/EastPerl.svg';
+
 interface IProps extends IAchievement { }
 
 interface IState { } // No state
@@ -43,7 +47,7 @@ export default class ActivityCard extends React.PureComponent<IProps, IState> {
       <Card className="sha-activity-card" title={title}>
         <Row>
           <Col span={10}>
-            <img src={img} alt="活动照片" width="100%" />
+            <LazyImg src={img} placeholder={IMAGE_PLACEHOLDER} alt="活动照片" width="100%"/>
           </Col>
           <Col offset={2} span={12}>
             <Timeline>

--- a/src/components/LazyImg.tsx
+++ b/src/components/LazyImg.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+type IState = {
+  loaded: boolean;
+}
+
+type IProps = {
+  src: string;
+  flushTimeout?: number;
+  width?: number | string;
+  height?: number | string;
+  alt?: string;
+  placeholder: string;
+}
+
+
+export default class LazyImg extends React.PureComponent<IProps, IState> {
+
+  constructor(props: IProps) {
+    super(props);
+
+    this.state = {
+      loaded: false
+    }
+  }
+
+  /**
+   * Refresh the component to update the loaded image
+   */
+  public onImgLoaded = () => {
+
+    let { flushTimeout } = this.props;
+
+    if (flushTimeout) {
+      setTimeout(() => {
+        this.setState({
+          loaded: true
+        });
+      }, flushTimeout);
+    } else {
+      this.setState({
+        loaded: true
+      });
+    }
+  }
+
+  render() {
+    let { loaded } = this.state;
+    let { src, width, height, alt, placeholder } = this.props;
+    return (
+      <>
+        {
+          loaded ?
+            <img src={src} width={width} height={height} alt={alt} />
+            :
+            <div>
+              <img src={src} style={{ display: 'none' }} onLoad={this.onImgLoaded} />
+              <img src={placeholder} width={width} height={'288.11px'} alt={alt} />
+            </div>
+        }
+      </>
+    )
+  }
+}


### PR DESCRIPTION
Per @homer-wh's suggestion, the image that we have in the activity page might be too large which might cause the picture being blank for a will, so I decided to have a placeholder here, thus after the image gets loaded, the placeholder will be automatically replaced by the real image